### PR TITLE
feat: add type param to Outbox interface

### DIFF
--- a/outbox_test.go
+++ b/outbox_test.go
@@ -67,15 +67,6 @@ var _ = Describe("Outbox", func() {
 			err := subject.SendTx(ctx, tx, data)
 			Expect(err).To(Succeed())
 		})
-
-		It("should return an error if the message is not the correct type", func() {
-			invalidMsg := struct{}{}
-
-			subject := outbox[testMessage]{}
-
-			err := subject.SendTx(context.Background(), nil, invalidMsg)
-			Expect(err).To(MatchError(errInvalidType))
-		})
 	})
 
 	Describe("#dispatch", func() {


### PR DESCRIPTION
## Description

This allows us to have structs holding the outbox with the correct msg type set, which makes go type checking work nicely.

## Changes

Changed the `Outbox` interface to `Outbox[T]`

## How did you test the changes?

Tests and compiler


<details>
<summary>Change Management</summary>
<a href="https://app.asana.com/0/1202267217415053/1205370506269609">Asana task</a>
</details>
