### PR TITLE
Fix transaction check

### DIFF
--- a/store/pg/pg.go
+++ b/store/pg/pg.go
@@ -198,7 +198,9 @@ func (s pgStore) Delete(ctx context.Context, id xid.ID) error {
 }
 
 func (s pgStore) ProcessTx(ctx context.Context, fn func(outbox.Store) bool) error {
-	db, ok := s.db.(*sql.DB)
+	db, ok := s.db.(interface {
+		BeginTx(context.Context, *sql.TxOptions) (*sql.Tx, error)
+	})
 	if !ok {
 		return errors.New("process transaction can only be called at the parent level")
 	}


### PR DESCRIPTION
## Description

Fixes an issue where the transaction check would return a false error if the `*sql.Tx` struct is embedded.

## How did you test the changes?

- Locally

## Dependencies

N/A


<details>
<summary>Change Management</summary>
<a href="https://app.asana.com/0/1202267217415053/1207164264837066">Asana task</a>
</details>
