### PR TITLE
breaking: Refactor to use slog exclusively

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/nrfta/go-outbox
 go 1.21
 
 require (
-	github.com/go-kit/log v0.2.1
 	github.com/lib/pq v1.10.9
 	github.com/nats-io/nats.go v1.36.0
 	github.com/neighborly/go-pghelpers v0.9.0
@@ -16,7 +15,6 @@ require (
 
 require (
 	github.com/DATA-DOG/go-txdb v0.1.6 // indirect
-	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-sql-driver/mysql v1.7.1 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/hpcloud/tail v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,6 @@ github.com/DATA-DOG/go-txdb v0.1.6 h1:D1Ob/L79mCW6UCFL6vwM/9TWs/rshZujxTsvy7+gic
 github.com/DATA-DOG/go-txdb v0.1.6/go.mod h1:DhAhxMXZpUJVGnT+p9IbzJoRKvlArO2pkHjnGX7o0n0=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
-github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
-github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
-github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=

--- a/outbox.go
+++ b/outbox.go
@@ -12,7 +12,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/rs/xid"
 )
 
@@ -96,14 +95,7 @@ func WithMaxRetries[T any](n int) option[T] {
 		o.maxRetries = n
 	}
 }
-
-func WithLogger[T any](logger log.Logger) option[T] {
-	return func(o *outbox[T]) {
-		o.logger = slog.Default()
-	}
-}
-
-func WithSlogLogger[T any](logger *slog.Logger) option[T] {
+func WithLogger[T any](logger *slog.Logger) option[T] {
 	return func(o *outbox[T]) {
 		if logger == nil {
 			logger = slog.Default()

--- a/store/pg/pg_test.go
+++ b/store/pg/pg_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/nrfta/go-outbox"
-	gomock "go.uber.org/mock/gomock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -17,19 +16,9 @@ import (
 )
 
 var _ = Describe("pgStore", func() {
-	var (
-		mockCtrl   *gomock.Controller
-		mockLogger *MockLogger
-	)
-
-	BeforeEach(func() {
-		mockCtrl = gomock.NewController(GinkgoT())
-		mockLogger = NewMockLogger(mockCtrl)
-	})
-
 	Describe("NewStore", func() {
 		It("should successfully create pgStore", func() {
-			subject, err := NewStore(db, connStr, nil)
+			subject, err := NewStore(db, connStr)
 			Expect(err).To(Succeed())
 			Expect(subject).ToNot(BeNil())
 		})
@@ -108,20 +97,9 @@ var _ = Describe("pgStore", func() {
 	})
 
 	Describe("#Listen", func() {
-		BeforeEach(func() {
-			mockLogger.EXPECT().Log(
-				gomock.Any(),
-				gomock.Any(),
-				gomock.Any(),
-				gomock.Any(),
-				gomock.Any(),
-				gomock.Any(),
-			)
-		})
-
 		It("should pull all new records on start", func() {
 			var (
-				subject = createStore(WithLogger(mockLogger))
+				subject = createStore()
 				ids     = []xid.ID{xid.New(), xid.New(), xid.New()}
 			)
 
@@ -149,7 +127,7 @@ var _ = Describe("pgStore", func() {
 
 		It("should send a new id to the returned channel when a new record is created", func() {
 			var (
-				subject = createStore(WithLogger(mockLogger))
+				subject = createStore()
 				idChan  = subject.Listen()
 				ctx     = context.Background()
 				tx, _   = db.BeginTx(ctx, nil)
@@ -255,7 +233,7 @@ var _ = Describe("pgStore", func() {
 })
 
 func createStore(opts ...option) *pgStore {
-	s, err := NewStore(db, connStr, nil, opts...)
+	s, err := NewStore(db, connStr, opts...)
 	Expect(err).To(Succeed())
 	return s
 }


### PR DESCRIPTION
## Description

Remove usage and references of go-kit/log, and move exclusively to slog.

## How did you test the changes?

Tests

## Dependencies

This change was made on top of the Nats PR. 

<details>
<summary>Change Management</summary>
<a href="https://app.asana.com/0/1202267217415053/1207852304101624">Asana task</a>
</details>
