### PR TITLE
fix(outbox): downgrade Skipping message log from INFO to DEBUG

### DIFF
--- a/outbox.go
+++ b/outbox.go
@@ -249,7 +249,7 @@ func (o outbox[T]) processMessageTx(ctx context.Context, id xid.ID) func(s Store
 		}
 
 		if errors.Is(err, errSkippingRecord) {
-			logger.InfoContext(
+			logger.DebugContext(
 				ctx,
 				"Skipping message",
 				slog.String("reason", err.Error()),


### PR DESCRIPTION
## Summary
- Downgrades the "Skipping message" log from INFO to DEBUG in the outbox processor
- This log fires for every outbox record already processed by another pod/goroutine, which is expected in multi-replica deployments
- At INFO level it produces thousands of noisy log lines that obscure meaningful output

## Test plan
- [x] Deploy sites-api with `go-outbox v0.5.1-beta.0` and verify "Skipping message" logs no longer appear at INFO level
- [x] Confirm "Successfully processed message" still logs at INFO
- [x] Verify outbox processing behavior is unchanged (messages still delivered correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)