### PR TITLE
Scalable outbox: dedicated connection pool, keyset pagination, dedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ go.work
 
 # Mock gen files
 mock*.go
+
+.claude/settings.local.json

--- a/outbox.go
+++ b/outbox.go
@@ -249,7 +249,7 @@ func (o outbox[T]) processMessageTx(ctx context.Context, id xid.ID) func(s Store
 		}
 
 		if errors.Is(err, errSkippingRecord) {
-			logger.InfoContext(
+			logger.DebugContext(
 				ctx,
 				"Skipping message",
 				slog.String("reason", err.Error()),

--- a/outbox.go
+++ b/outbox.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/rs/xid"
@@ -147,11 +148,20 @@ func (o outbox[T]) SendTx(ctx context.Context, tx *sql.Tx, msg T) error {
 
 func (o outbox[T]) dispatch() {
 	tokens := make(chan struct{}, o.numRoutines)
+	var inFlight sync.Map
+
 	for id := range o.store.Listen() {
+		if _, loaded := inFlight.LoadOrStore(id, struct{}{}); loaded {
+			continue
+		}
+
 		tokens <- struct{}{}
 		go func(id xid.ID) {
+			defer func() {
+				inFlight.Delete(id)
+				<-tokens
+			}()
 			o.process(id)
-			<-tokens
 		}(id)
 	}
 }

--- a/store/pg/pg.go
+++ b/store/pg/pg.go
@@ -74,8 +74,8 @@ func NewStore(db execQuerier, connStr string, opts ...option) (*Store, error) {
 		connStr:        connStr,
 		chanName:       "",
 		logger:         slog.Default(),
-		pageSize:       20,
-		chanBufferSize: 100,
+		pageSize:       6,
+		chanBufferSize: 5,
 	}
 
 	for _, o := range opts {
@@ -187,46 +187,66 @@ func (s Store) getRecordIDs(idChan chan xid.ID) error {
 }
 
 func (s Store) fetchPage(idChan chan xid.ID, lastID *string) (int, error) {
+	ids, err := s.queryPage(*lastID)
+	if err != nil {
+		return 0, err
+	}
+
+	// Send to the channel outside of the DB context so that blocking on a
+	// full channel does not hold open rows or trigger a context timeout.
+	for _, id := range ids {
+		idChan <- id
+	}
+
+	if len(ids) > 0 {
+		*lastID = ids[len(ids)-1].String()
+	}
+
+	return len(ids), nil
+}
+
+// queryPage executes a single keyset-paginated query and returns up to
+// pageSize IDs. The context timeout only covers the DB round-trip; channel
+// backpressure cannot cause it to expire.
+func (s Store) queryPage(afterID string) ([]xid.ID, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	var query string
 	var args []any
-	if *lastID == "" {
+	if afterID == "" {
 		query = fmt.Sprintf(`SELECT id FROM %s ORDER BY id LIMIT %d;`, s.tableName, s.pageSize)
 	} else {
 		query = fmt.Sprintf(`SELECT id FROM %s WHERE id > $1 ORDER BY id LIMIT %d;`, s.tableName, s.pageSize)
-		args = []any{*lastID}
+		args = []any{afterID}
 	}
 
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	defer rows.Close()
 
-	numRows := 0
+	var ids []xid.ID
 	for rows.Next() {
 		var rawID string
 		if err := rows.Scan(&rawID); err != nil {
-			return 0, err
+			return nil, err
 		}
 
 		id, err := xid.FromString(rawID)
 		if err != nil {
-			return 0, err
+			return nil, err
 		}
 
-		idChan <- id
-		*lastID = rawID
-		numRows++
+		ids = append(ids, id)
 	}
 
 	if err := rows.Err(); err != nil {
-		return 0, err
+		return nil, err
 	}
 
-	return numRows, nil
+	return ids, nil
 }
 
 func (s Store) GetWithLock(ctx context.Context, id xid.ID) (*outbox.Record, error) {

--- a/store/pg/pg.go
+++ b/store/pg/pg.go
@@ -141,18 +141,9 @@ func (s Store) Listen() <-chan xid.ID {
 		s.chanName,
 	)
 
-	// Ping the listner every 90 seconds to ensure it stays connected and receives notifications in a timely manner.
-	pingTicker := time.NewTicker(90 * time.Second)
-	go func(l *pq.Listener) {
-		for range pingTicker.C {
-			if err := l.Ping(); err != nil {
-				logger.Error("error pinging listener", "error", err)
-			}
-		}
-	}(listener)
-
 	idChan := make(chan xid.ID, s.chanBufferSize)
 	go func(l *pq.Listener) {
+		defer l.Close()
 		for {
 			err := s.getRecordIDs(idChan)
 			if err != nil {
@@ -164,6 +155,7 @@ func (s Store) Listen() <-chan xid.ID {
 			case <-l.Notify:
 				// New record(s) available to process
 			case <-time.After(90 * time.Second):
+				l.Ping()
 				// Check if there's more work available, just in case it takes a while
 				// for the Listener to notice connection loss and reconnect.
 			}

--- a/store/pg/pg.go
+++ b/store/pg/pg.go
@@ -23,7 +23,6 @@ type execQuerier interface {
 
 type Store struct {
 	db               execQuerier
-	consumerDB       *sql.DB // dedicated pool for consumer operations (queryPage, ProcessTx)
 	tableName        string
 	connStr          string
 	chanName         string
@@ -106,6 +105,8 @@ func NewStore(db execQuerier, connStr string, opts ...option) (*Store, error) {
 		"_",
 	)
 
+	// dedicated pool for consumer operations (queryPage, ProcessTx) so that Listen can keep polling
+	// for new work even if the caller is doing long-running work or has a slow connection
 	consumerDB, err := sql.Open("postgres", connStr)
 	if err != nil {
 		return nil, fmt.Errorf("open consumer db pool: %w", err)
@@ -116,7 +117,6 @@ func NewStore(db execQuerier, connStr string, opts ...option) (*Store, error) {
 		consumerDB.Close()
 		return nil, fmt.Errorf("ping consumer db pool: %w", err)
 	}
-	s.consumerDB = consumerDB
 	s.db = consumerDB
 
 	if err := s.init(); err != nil {
@@ -136,8 +136,12 @@ func (s *Store) Close() error {
 	default:
 		close(s.done)
 	}
-	if s.consumerDB != nil {
-		return s.consumerDB.Close()
+	if s.db != nil {
+		if db, ok := s.db.(interface {
+			Close() error
+		}); ok {
+			db.Close()
+		}
 	}
 	return nil
 }
@@ -260,7 +264,7 @@ func (s Store) queryPage(afterID string) ([]xid.ID, error) {
 		args = []any{afterID}
 	}
 
-	rows, err := s.consumerDB.QueryContext(ctx, query, args...)
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -331,11 +335,14 @@ func (s Store) Delete(ctx context.Context, id xid.ID) error {
 }
 
 func (s Store) ProcessTx(ctx context.Context, fn func(outbox.Store) bool) error {
-	if s.consumerDB == nil {
+	db, ok := s.db.(interface {
+		BeginTx(context.Context, *sql.TxOptions) (*sql.Tx, error)
+	})
+	if !ok {
 		return errors.New("process transaction can only be called at the parent level")
 	}
 
-	tx, err := s.consumerDB.BeginTx(ctx, nil)
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("unable to create transaction: %v", err)
 	}

--- a/store/pg/pg.go
+++ b/store/pg/pg.go
@@ -22,11 +22,13 @@ type execQuerier interface {
 }
 
 type Store struct {
-	db        execQuerier
-	tableName string
-	connStr   string
-	chanName  string
-	logger    *slog.Logger
+	db             execQuerier
+	tableName      string
+	connStr        string
+	chanName       string
+	logger         *slog.Logger
+	pageSize       int
+	chanBufferSize int
 }
 
 type option func(s *Store)
@@ -47,15 +49,33 @@ func WithLogger(logger *slog.Logger) option {
 	}
 }
 
+func WithPageSize(n int) option {
+	return func(s *Store) {
+		if n > 0 {
+			s.pageSize = n
+		}
+	}
+}
+
+func WithChannelBufferSize(n int) option {
+	return func(s *Store) {
+		if n > 0 {
+			s.chanBufferSize = n
+		}
+	}
+}
+
 var _ outbox.Store = &Store{}
 
 func NewStore(db execQuerier, connStr string, opts ...option) (*Store, error) {
 	s := &Store{
-		db,
-		"outbox",
-		connStr,
-		"",
-		slog.Default(),
+		db:             db,
+		tableName:      "outbox",
+		connStr:        connStr,
+		chanName:       "",
+		logger:         slog.Default(),
+		pageSize:       20,
+		chanBufferSize: 100,
 	}
 
 	for _, o := range opts {
@@ -121,24 +141,29 @@ func (s Store) Listen() <-chan xid.ID {
 		s.chanName,
 	)
 
-	idChan := make(chan xid.ID, 1)
+	// Ping the listner every 90 seconds to ensure it stays connected and receives notifications in a timely manner.
+	pingTicker := time.NewTicker(90 * time.Second)
+	go func(l *pq.Listener) {
+		for range pingTicker.C {
+			if err := l.Ping(); err != nil {
+				logger.Error("error pinging listener", "error", err)
+			}
+		}
+	}(listener)
+
+	idChan := make(chan xid.ID, s.chanBufferSize)
 	go func(l *pq.Listener) {
 		for {
-			ids, err := s.getRecordIDs()
+			err := s.getRecordIDs(idChan)
 			if err != nil {
 				s.logger.Error("unable to get record ids", "error", err)
 				continue
-			}
-
-			for _, i := range ids {
-				idChan <- i
 			}
 
 			select {
 			case <-l.Notify:
 				// New record(s) available to process
 			case <-time.After(90 * time.Second):
-				go l.Ping()
 				// Check if there's more work available, just in case it takes a while
 				// for the Listener to notice connection loss and reconnect.
 			}
@@ -148,36 +173,60 @@ func (s Store) Listen() <-chan xid.ID {
 	return idChan
 }
 
-func (s Store) getRecordIDs() ([]xid.ID, error) {
-	var res []xid.ID
+func (s Store) getRecordIDs(idChan chan xid.ID) error {
+	var lastID string
+	for {
+		n, err := s.fetchPage(idChan, &lastID)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return nil
+		}
+	}
+}
+
+func (s Store) fetchPage(idChan chan xid.ID, lastID *string) (int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	query := fmt.Sprintf(`
-	SELECT id FROM %s;
-	`, s.tableName)
+	var query string
+	var args []any
+	if *lastID == "" {
+		query = fmt.Sprintf(`SELECT id FROM %s ORDER BY id LIMIT %d;`, s.tableName, s.pageSize)
+	} else {
+		query = fmt.Sprintf(`SELECT id FROM %s WHERE id > $1 ORDER BY id LIMIT %d;`, s.tableName, s.pageSize)
+		args = []any{*lastID}
+	}
 
-	rows, err := s.db.QueryContext(ctx, query)
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	defer rows.Close()
 
+	numRows := 0
 	for rows.Next() {
 		var rawID string
 		if err := rows.Scan(&rawID); err != nil {
-			return nil, err
+			return 0, err
 		}
 
 		id, err := xid.FromString(rawID)
 		if err != nil {
-			return nil, err
+			return 0, err
 		}
 
-		res = append(res, id)
+		idChan <- id
+		*lastID = rawID
+		numRows++
 	}
 
-	return res, nil
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	return numRows, nil
 }
 
 func (s Store) GetWithLock(ctx context.Context, id xid.ID) (*outbox.Record, error) {
@@ -236,8 +285,11 @@ func (s Store) ProcessTx(ctx context.Context, fn func(outbox.Store) bool) error 
 	}
 
 	store := Store{
-		db:        tx,
-		tableName: s.tableName,
+		db:             tx,
+		tableName:      s.tableName,
+		logger:         s.logger,
+		pageSize:       s.pageSize,
+		chanBufferSize: s.chanBufferSize,
 	}
 
 	if success := fn(store); !success {

--- a/store/pg/pg.go
+++ b/store/pg/pg.go
@@ -22,13 +22,16 @@ type execQuerier interface {
 }
 
 type Store struct {
-	db             execQuerier
-	tableName      string
-	connStr        string
-	chanName       string
-	logger         *slog.Logger
-	pageSize       int
-	chanBufferSize int
+	db               execQuerier
+	consumerDB       *sql.DB // dedicated pool for consumer operations (queryPage, ProcessTx)
+	tableName        string
+	connStr          string
+	chanName         string
+	logger           *slog.Logger
+	pageSize         int
+	chanBufferSize   int
+	maxConsumerConns int
+	done             chan struct{}
 }
 
 type option func(s *Store)
@@ -65,17 +68,27 @@ func WithChannelBufferSize(n int) option {
 	}
 }
 
+func WithMaxConsumerConns(n int) option {
+	return func(s *Store) {
+		if n > 0 {
+			s.maxConsumerConns = n
+		}
+	}
+}
+
 var _ outbox.Store = &Store{}
 
 func NewStore(db execQuerier, connStr string, opts ...option) (*Store, error) {
 	s := &Store{
-		db:             db,
-		tableName:      "outbox",
-		connStr:        connStr,
-		chanName:       "",
-		logger:         slog.Default(),
-		pageSize:       6,
-		chanBufferSize: 5,
+		db:               db,
+		tableName:        "outbox",
+		connStr:          connStr,
+		chanName:         "",
+		logger:           slog.Default(),
+		pageSize:         6,
+		chanBufferSize:   5,
+		maxConsumerConns: 8,
+		done:             make(chan struct{}),
 	}
 
 	for _, o := range opts {
@@ -93,11 +106,39 @@ func NewStore(db execQuerier, connStr string, opts ...option) (*Store, error) {
 		"_",
 	)
 
+	consumerDB, err := sql.Open("postgres", connStr)
+	if err != nil {
+		return nil, fmt.Errorf("open consumer db pool: %w", err)
+	}
+	consumerDB.SetMaxOpenConns(s.maxConsumerConns)
+	consumerDB.SetMaxIdleConns(s.maxConsumerConns)
+	if err := consumerDB.Ping(); err != nil {
+		consumerDB.Close()
+		return nil, fmt.Errorf("ping consumer db pool: %w", err)
+	}
+	s.consumerDB = consumerDB
+
 	if err := s.init(); err != nil {
+		consumerDB.Close()
 		return nil, err
 	}
 
 	return s, nil
+}
+
+// Close signals the Listen goroutine to stop and shuts down the dedicated
+// consumer connection pool. It does not close the caller-owned db passed to NewStore.
+func (s *Store) Close() error {
+	select {
+	case <-s.done:
+		// already closed
+	default:
+		close(s.done)
+	}
+	if s.consumerDB != nil {
+		return s.consumerDB.Close()
+	}
+	return nil
 }
 
 func (s Store) CreateRecordTx(ctx context.Context, tx *sql.Tx, r outbox.Record) (*outbox.Record, error) {
@@ -145,13 +186,20 @@ func (s Store) Listen() <-chan xid.ID {
 	go func(l *pq.Listener) {
 		defer l.Close()
 		for {
+			select {
+			case <-s.done:
+				return
+			default:
+			}
+
 			err := s.getRecordIDs(idChan)
 			if err != nil {
 				s.logger.Error("unable to get record ids", "error", err)
-				continue
 			}
 
 			select {
+			case <-s.done:
+				return
 			case <-l.Notify:
 				// New record(s) available to process
 			case <-time.After(90 * time.Second):
@@ -187,7 +235,11 @@ func (s Store) fetchPage(idChan chan xid.ID, lastID *string) (int, error) {
 	// Send to the channel outside of the DB context so that blocking on a
 	// full channel does not hold open rows or trigger a context timeout.
 	for _, id := range ids {
-		idChan <- id
+		select {
+		case idChan <- id:
+		case <-s.done:
+			return 0, nil
+		}
 	}
 
 	if len(ids) > 0 {
@@ -213,7 +265,7 @@ func (s Store) queryPage(afterID string) ([]xid.ID, error) {
 		args = []any{afterID}
 	}
 
-	rows, err := s.db.QueryContext(ctx, query, args...)
+	rows, err := s.consumerDB.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -284,14 +336,11 @@ func (s Store) Delete(ctx context.Context, id xid.ID) error {
 }
 
 func (s Store) ProcessTx(ctx context.Context, fn func(outbox.Store) bool) error {
-	db, ok := s.db.(interface {
-		BeginTx(context.Context, *sql.TxOptions) (*sql.Tx, error)
-	})
-	if !ok {
+	if s.consumerDB == nil {
 		return errors.New("process transaction can only be called at the parent level")
 	}
 
-	tx, err := db.BeginTx(ctx, nil)
+	tx, err := s.consumerDB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("unable to create transaction: %v", err)
 	}

--- a/store/pg/pg.go
+++ b/store/pg/pg.go
@@ -155,7 +155,7 @@ func (s Store) Listen() <-chan xid.ID {
 			case <-l.Notify:
 				// New record(s) available to process
 			case <-time.After(90 * time.Second):
-				l.Ping()
+				go l.Ping()
 				// Check if there's more work available, just in case it takes a while
 				// for the Listener to notice connection loss and reconnect.
 			}

--- a/store/pg/pg.go
+++ b/store/pg/pg.go
@@ -117,6 +117,7 @@ func NewStore(db execQuerier, connStr string, opts ...option) (*Store, error) {
 		return nil, fmt.Errorf("ping consumer db pool: %w", err)
 	}
 	s.consumerDB = consumerDB
+	s.db = consumerDB
 
 	if err := s.init(); err != nil {
 		consumerDB.Close()
@@ -186,12 +187,6 @@ func (s Store) Listen() <-chan xid.ID {
 	go func(l *pq.Listener) {
 		defer l.Close()
 		for {
-			select {
-			case <-s.done:
-				return
-			default:
-			}
-
 			err := s.getRecordIDs(idChan)
 			if err != nil {
 				s.logger.Error("unable to get record ids", "error", err)

--- a/store/pg/pg.go
+++ b/store/pg/pg.go
@@ -303,6 +303,7 @@ func (s Store) ProcessTx(ctx context.Context, fn func(outbox.Store) bool) error 
 	if err != nil {
 		return fmt.Errorf("unable to create transaction: %v", err)
 	}
+	defer tx.Rollback() // no-op after Commit; silently handles context cancellation
 
 	store := Store{
 		db:             tx,
@@ -313,7 +314,7 @@ func (s Store) ProcessTx(ctx context.Context, fn func(outbox.Store) bool) error 
 	}
 
 	if success := fn(store); !success {
-		return tx.Rollback()
+		return nil // rollback handled by defer; real error already logged in callback
 	}
 
 	return tx.Commit()

--- a/store/pg/pg_suite_test.go
+++ b/store/pg/pg_suite_test.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	db      *sql.DB
-	connStr = getConfig().GenerateAddress()
+	connStr string
 )
 
 func TestIntegration(t *testing.T) {
@@ -28,6 +28,7 @@ var _ = BeforeEach(func() {
 	var err error
 	cfg := getConfig()
 	cfg.Database = "outbox_test"
+	connStr = cfg.GenerateAddress()
 	db, err = pghelpers.ConnectPostgres(*cfg)
 	Expect(err).To(Succeed())
 })

--- a/store/pg/pg_test.go
+++ b/store/pg/pg_test.go
@@ -21,6 +21,38 @@ var _ = Describe("pgStore", func() {
 			subject, err := NewStore(db, connStr)
 			Expect(err).To(Succeed())
 			Expect(subject).ToNot(BeNil())
+			defer subject.Close()
+		})
+
+		It("should create a separate consumer pool", func() {
+			subject, err := NewStore(db, connStr)
+			Expect(err).To(Succeed())
+			defer subject.Close()
+
+			Expect(subject.consumerDB).ToNot(BeNil())
+			Expect(subject.consumerDB.Ping()).To(Succeed())
+		})
+
+		It("should respect WithMaxConsumerConns option", func() {
+			subject, err := NewStore(db, connStr, WithMaxConsumerConns(3))
+			Expect(err).To(Succeed())
+			defer subject.Close()
+
+			stats := subject.consumerDB.Stats()
+			Expect(stats.MaxOpenConnections).To(Equal(3))
+		})
+	})
+
+	Describe("#Close", func() {
+		It("should close the consumer pool without error", func() {
+			subject, err := NewStore(db, connStr)
+			Expect(err).To(Succeed())
+
+			err = subject.Close()
+			Expect(err).To(Succeed())
+
+			err = subject.consumerDB.Ping()
+			Expect(err).To(HaveOccurred())
 		})
 	})
 
@@ -37,6 +69,10 @@ var _ = Describe("pgStore", func() {
 			subject = createStore()
 			ctx = context.Background()
 			tx, _ = db.BeginTx(ctx, nil)
+		})
+
+		AfterEach(func() {
+			subject.Close()
 		})
 
 		It("should save the provided record on a successfull transaction", func() {
@@ -74,6 +110,10 @@ var _ = Describe("pgStore", func() {
 			Expect(err).To(Succeed())
 		})
 
+		AfterEach(func() {
+			subject.Close()
+		})
+
 		It("should return a record on a valid id", func() {
 			subject.ProcessTx(ctx, func(s outbox.Store) bool {
 				res, err := s.GetWithLock(ctx, id)
@@ -102,6 +142,7 @@ var _ = Describe("pgStore", func() {
 				subject = createStore()
 				ids     = []xid.ID{xid.New(), xid.New(), xid.New()}
 			)
+			defer subject.Close()
 
 			for _, id := range ids {
 				_ = insertRecord(db, outbox.Record{ID: id, Message: []byte("data")})
@@ -132,6 +173,7 @@ var _ = Describe("pgStore", func() {
 				ctx     = context.Background()
 				tx, _   = db.BeginTx(ctx, nil)
 			)
+			defer subject.Close()
 
 			res, err := subject.CreateRecordTx(ctx, tx, outbox.Record{})
 			tx.Commit()
@@ -147,6 +189,7 @@ var _ = Describe("pgStore", func() {
 				subject = createStore()
 				id      = xid.New()
 			)
+			defer subject.Close()
 
 			_ = insertRecord(db, outbox.Record{ID: id, Message: []byte("data")})
 
@@ -164,6 +207,7 @@ var _ = Describe("pgStore", func() {
 				subject = createStore()
 				id      = xid.New()
 			)
+			defer subject.Close()
 
 			_ = insertRecord(db, outbox.Record{ID: id, Message: []byte("data")})
 
@@ -220,6 +264,7 @@ var _ = Describe("pgStore", func() {
 			)
 
 			_ = insertRecord(db, record)
+			defer subject.Close()
 
 			err := subject.Update(context.Background(), &record)
 			Expect(err).To(Succeed())

--- a/store/pg/pg_test.go
+++ b/store/pg/pg_test.go
@@ -29,8 +29,8 @@ var _ = Describe("pgStore", func() {
 			Expect(err).To(Succeed())
 			defer subject.Close()
 
-			Expect(subject.consumerDB).ToNot(BeNil())
-			Expect(subject.consumerDB.Ping()).To(Succeed())
+			Expect(subject.db).ToNot(BeNil())
+			Expect(subject.db.(interface{ Ping() error }).Ping()).To(Succeed())
 		})
 
 		It("should respect WithMaxConsumerConns option", func() {
@@ -38,7 +38,7 @@ var _ = Describe("pgStore", func() {
 			Expect(err).To(Succeed())
 			defer subject.Close()
 
-			stats := subject.consumerDB.Stats()
+			stats := subject.db.(interface{ Stats() sql.DBStats }).Stats()
 			Expect(stats.MaxOpenConnections).To(Equal(3))
 		})
 	})
@@ -51,7 +51,7 @@ var _ = Describe("pgStore", func() {
 			err = subject.Close()
 			Expect(err).To(Succeed())
 
-			err = subject.consumerDB.Ping()
+			err = subject.db.(interface{ Ping() error }).Ping()
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
## Problem

At scale, the outbox consumer was experiencing `context deadline exceeded` errors and blocking behavior. Root cause analysis identified three compounding issues:

1. **Connection pool starvation** — The outbox consumer shared a `*sql.DB` pool with the API resolvers. Long-running mutations (e.g. `createServiceableAddresses`) would exhaust the pool, starving the outbox consumer's `SELECT` and `FOR UPDATE` queries until the mutation completed or timed out.

2. **Unbounded table scan** — `SELECT id FROM outbox` loaded every row into memory in a single query, causing context deadline timeouts as the table grew.

## Changes

### Dedicated consumer connection pool (`store/pg/pg.go`)
- Creates a separate `*sql.DB` from `connStr` with configurable `MaxOpenConns` (default 8)
- All consumer operations (`queryPage`, `ProcessTx`, `GetWithLock`, `Delete`) run on this isolated pool
- The caller's `db` parameter is accepted for backward compatibility but no longer stored
- Added `Close()` method and `done` channel for clean shutdown and goroutine lifecycle
- Added `WithMaxConsumerConns(n)` option

### Keyset pagination (`store/pg/pg.go`)
- Replaced `SELECT id FROM outbox` with `SELECT id FROM outbox WHERE id > $1 ORDER BY id LIMIT N`
- O(1) per page via primary key index, stable under concurrent inserts/deletes
- Split into `queryPage` (DB-scoped context) and `fetchPage` (channel sends) so backpressure cannot trigger context timeouts
- Added `WithPageSize(n)` and `WithChannelBufferSize(n)` options
- Defaults tuned to `chanBufferSize=5`, `pageSize=6` — producer blocks on the 6th item, keeping the consumer saturated while minimizing duplicate-read windows across pods

### In-flight deduplication (`outbox.go`)
- Added `sync.Map` to track IDs currently being processed
- Duplicate IDs from overlapping scans are skipped (`LoadOrStore` / `Delete` around process)

### ProcessTx rollback safety (`store/pg/pg.go`)
- Added `defer tx.Rollback()` to handle context cancellation gracefully (no-op after commit)
- Eliminated noisy `sql: transaction has already been committed or rolled back` errors

### Listener lifecycle (`store/pg/pg.go`)
- Added `defer l.Close()` in Listen goroutine
- Moved `l.Ping()` back into the `time.After` select case (only needed when idle)
- Removed redundant pre-check `select` on `done` channel
- Added `rows.Err()` check after row iteration

### Tests (`store/pg/pg_test.go`, `store/pg/pg_suite_test.go`)
- Added tests for dedicated consumer pool creation, `WithMaxConsumerConns`, and `Close()`
- Added `defer subject.Close()` to all test cases
- Fixed `connStr` initialization in test suite setup

## Test plan
- [x] `go test ./store/pg/...` passes
- [x] Verified under load — context deadline errors resolved
- [x] Confirmed outbox processes messages concurrently with long-running API mutations
- [x] Keyset pagination handles concurrent inserts/deletes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)