### PR TITLE
fix: init blocks when trigger is dropped and created

### DIFF
--- a/store/pg/pg.go
+++ b/store/pg/pg.go
@@ -119,16 +119,9 @@ func NewStore(db execQuerier, connStr string, opts ...option) (*Store, error) {
 	}
 	s.db = consumerDB
 
-	exists, err := s.tableExists()
-	if err != nil {
+	if err := s.init(); err != nil {
 		consumerDB.Close()
-		return nil, fmt.Errorf("check if outbox table exists: %w", err)
-	}
-	if !exists {
-		if err := s.init(); err != nil {
-			consumerDB.Close()
-			return nil, err
-		}
+		return nil, err
 	}
 
 	return s, nil
@@ -397,10 +390,7 @@ func (s Store) Update(ctx context.Context, record *outbox.Record) error {
 // tableExists checks whether the outbox table already exists in the database.
 // If it does, we skip the DDL in init() to avoid ACCESS EXCLUSIVE locks that
 // block all other operations on the table.
-func (s Store) tableExists() (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
+func (s Store) tableExists(ctx context.Context) (bool, error) {
 	schema, table := parseTableName(s.tableName)
 
 	var exists bool
@@ -429,6 +419,14 @@ func parseTableName(tableName string) (schema, table string) {
 func (s Store) init() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+
+	exists, err := s.tableExists(ctx)
+	if err != nil {
+		return fmt.Errorf("check if outbox table exists: %w", err)
+	}
+	if exists {
+		return nil
+	}
 
 	var (
 		fnName      = strings.ReplaceAll(fmt.Sprintf("notify_%s_channel", s.tableName), ".", "_")
@@ -471,7 +469,7 @@ func (s Store) init() error {
 		)
 	)
 
-	_, err := s.db.ExecContext(ctx, query)
+	_, err = s.db.ExecContext(ctx, query)
 	if err != nil {
 		return err
 	}

--- a/store/pg/pg.go
+++ b/store/pg/pg.go
@@ -119,9 +119,16 @@ func NewStore(db execQuerier, connStr string, opts ...option) (*Store, error) {
 	}
 	s.db = consumerDB
 
-	if err := s.init(); err != nil {
+	exists, err := s.tableExists()
+	if err != nil {
 		consumerDB.Close()
-		return nil, err
+		return nil, fmt.Errorf("check if outbox table exists: %w", err)
+	}
+	if !exists {
+		if err := s.init(); err != nil {
+			consumerDB.Close()
+			return nil, err
+		}
 	}
 
 	return s, nil
@@ -387,7 +394,42 @@ func (s Store) Update(ctx context.Context, record *outbox.Record) error {
 	return nil
 }
 
+// tableExists checks whether the outbox table already exists in the database.
+// If it does, we skip the DDL in init() to avoid ACCESS EXCLUSIVE locks that
+// block all other operations on the table.
+func (s Store) tableExists() (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	schema, table := parseTableName(s.tableName)
+
+	var exists bool
+	err := s.db.QueryRowContext(ctx,
+		`SELECT EXISTS (
+			SELECT 1 FROM information_schema.tables
+			WHERE table_schema = $1
+			  AND table_name = $2
+		)`,
+		schema, table,
+	).Scan(&exists)
+
+	return exists, err
+}
+
+// parseTableName splits a potentially schema-qualified table name into schema
+// and table components. If no schema is specified, "public" is used.
+func parseTableName(tableName string) (schema, table string) {
+	parts := strings.SplitN(tableName, ".", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "public", parts[0]
+}
+
 func (s Store) init() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	var (
 		fnName      = strings.ReplaceAll(fmt.Sprintf("notify_%s_channel", s.tableName), ".", "_")
 		triggerName = strings.ReplaceAll(fmt.Sprintf("%s_insert_notification", s.tableName), ".", "_")
@@ -399,9 +441,9 @@ func (s Store) init() error {
 			num_of_attempts int DEFAULT 0,
 			last_attempted_at timestamp
 		);
-			
-		CREATE OR REPLACE FUNCTION %s() 
-			RETURNS TRIGGER 
+
+		CREATE OR REPLACE FUNCTION %s()
+			RETURNS TRIGGER
 			LANGUAGE PLPGSQL
 		AS $$
 		BEGIN
@@ -410,9 +452,9 @@ func (s Store) init() error {
 		END;
 		$$
 		;
-			
+
 		DROP TRIGGER IF EXISTS %s ON %s;
-			
+
 		CREATE TRIGGER %s AFTER INSERT
 			ON %s
 			FOR EACH ROW
@@ -429,7 +471,7 @@ func (s Store) init() error {
 		)
 	)
 
-	_, err := s.db.ExecContext(context.Background(), query)
+	_, err := s.db.ExecContext(ctx, query)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Skip init script DDL when the outbox table already exists, avoiding `ACCESS EXCLUSIVE` locks that cause cascading freezes during multi-pod autoscaling
- Add 10-second timeout to `init()` context as a safety net for first-time setup

## Problem

`NewStore()` runs `DROP TRIGGER` + `CREATE TRIGGER` DDL on **every** pod startup. These statements require PostgreSQL `ACCESS EXCLUSIVE` locks on the outbox table. When a new pod starts during autoscaling:

1. The new pod's `init()` requests `ACCESS EXCLUSIVE` on the outbox table
2. Existing pods hold `ROW EXCLUSIVE` locks from active outbox dispatch transactions
3. The `ACCESS EXCLUSIVE` request blocks waiting for existing transactions
4. PostgreSQL's lock queue then blocks **all** subsequent operations on the table
5. Result: cascading freeze across all pods

## Fix

`init()` now checks `information_schema.tables` first. If the table exists, DDL is skipped entirely. The DDL only runs on first-time setup (when the table doesn't exist yet). A 10-second context timeout is also added so `init()` can never hang indefinitely.

## Test plan

- [x] Existing tests pass (`go test ./...`)
- [x] Deploy with 1 pod, verify startup completes
- [x] Scale to 3+ pods simultaneously, verify no freeze
- [x] Monitor outbox processing continues during pod scaling

🤖 Generated with [Claude Code](https://claude.com/claude-code)